### PR TITLE
Fix scrollbar wrapper preventing clicks

### DIFF
--- a/src/components/SidebarMenu.vue
+++ b/src/components/SidebarMenu.vue
@@ -8,7 +8,6 @@
     <slot name="header" />
     <div
       class="vsm--scroll-wrapper"
-      :style="isCollapsed && [rtl ? {'margin-left': '-17px'} : {'margin-right': '-17px'}]"
     >
       <div
         class="vsm--list"
@@ -99,7 +98,7 @@ export default {
     },
     widthCollapsed: {
       type: String,
-      default: '50px'
+      default: '60px'
     },
     showChild: {
       type: Boolean,


### PR DESCRIPTION
Makes the sidebar slightly wider by default
There is now space inside the sidebar to fit a scroll bar for small screens.